### PR TITLE
update OB 1179

### DIFF
--- a/issues/1179/amendments.yaml
+++ b/issues/1179/amendments.yaml
@@ -551,4 +551,6 @@ messages:
           - type: paragraph
             content:
               - type: text
-                text: See also page 5 of this ITU Operational Bulletin No. 1179
+                text: >-
+                  See also Data Transmission Service message in this ITU
+                  Operational Bulletin No. 1179


### PR DESCRIPTION
Fix reference: refer to message within the same OB using message title instead of OB document page.